### PR TITLE
Update to Python 3.11 and set POWERTOOLS_SERVICE_NAME for Python Lambda functions

### DIFF
--- a/CustomIdentityComponent/lambda/login_with_steam.py
+++ b/CustomIdentityComponent/lambda/login_with_steam.py
@@ -3,9 +3,9 @@
 
 import boto3
 from botocore.config import Config
+import datetime
 import uuid
 import os
-import jwt
 from encryption_and_decryption import encrypt, decrypt
 import json
 import requests
@@ -18,7 +18,8 @@ logger = Logger()
 config = Config(connect_timeout=2, read_timeout=2)
 dynamodb = boto3.resource('dynamodb', config=config)
 
-steam_token_validation_api_endpoint = "https://api.steampowered.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
+# partner.steam-api.com is the server to server endpoint per https://partner.steamgames.com/doc/webapi_overview#3 
+steam_token_validation_api_endpoint = "https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
 
 # Steam Web Api key from Secrets manager, cached between requests for 15 minutes
 steam_web_api_key = None
@@ -30,11 +31,11 @@ def refresh_steam_web_api_key_if_needed():
     # get time difference between current time and last_private_key_refresh
     current_time = int(time.time())
     time_difference = current_time - last_steam_web_api_key_refresh
-    print("Time difference between current time and last_steam_web_api_key_refresh: ", time_difference)
+    logger.debug("Time difference between current time and last_steam_web_api_key_refresh: ", time_difference)
 
     # check if we need to refresh the private key (every 30 minutes as this changes rarely if ever)
     if time_difference > 1800 or steam_web_api_key == None:
-        print("Refreshing Steam web api key")
+        logger.info("Refreshing Steam web api key")
 
         # get private key from AWS Secrets Manager
         secret_arn= os.environ['STEAM_WEB_API_KEY_SECRET_ARN']
@@ -100,13 +101,6 @@ def generate_success(user_id, steam_id, jwt_token, refresh_token, auth_token_exp
         "isBase64Encoded": False
     }
 
-@tracer.capture_method
-def find_key_with_kid(key_set, kid):
-    for key in key_set:
-        if key["kid"] == kid:
-            return jwt.algorithms.RSAAlgorithm.from_jwk(key)
-    return None
-
 # Tries to get an existing user from User Table. Reports error if request fails
 @tracer.capture_method
 def get_existing_user(steam_id):
@@ -132,7 +126,7 @@ def add_new_user_to_steam_table(user_id, steam_id):
         steam_id_user_table.put_item(
         Item={
             'UserId': user_id,
-            'SteamId': steam_id, # NOTE: You might want to add other information from the Steam API response too
+            'SteamId': steam_id,
         });
         return True
     except Exception as e:
@@ -161,6 +155,50 @@ def link_steam_id_to_existing_user(user_id, steam_id):
     
     return False
 
+def check_steam_token(token: str) -> str:
+    response = None
+    response_body = {}
+    while True:
+        send_time = datetime.datetime.utcnow()
+        response = requests.get(steam_token_validation_api_endpoint, 
+                                params={'key': steam_web_api_key, 'appid': os.environ['STEAM_APP_ID'], 'ticket': token})
+        elapsed_ms = round(((datetime.datetime.utcnow()-send_time).microseconds)/1000)
+        logger.debug(f'Steam response', elapsed_ms=elapsed_ms, code=response.status_code, headers=response.headers, body=response.text)
+        
+        if response.status_code != 200:
+            logger.error("Steam returned an error", response_code=response.status_code)
+            return None
+
+        response_body = response.json()
+
+        # retry on error code 103 after a second
+        if response_body.get('response', {}).get('error', {}).get('errorcode', 0) != 103:
+            break
+
+        logger.info("Received 103, retrying after a delay")
+        time.sleep(1)
+
+    response_dict = response_body.get('response', {}).get('params', {})
+    if not 'result' in response_dict or response_dict['result'] != 'OK':
+        logger.info("Result in not OK", result= response_dict['result'])
+        return None
+    
+    if not 'steamid' in response_dict:
+        logger.error("steamid missing", response=response_dict)
+        return None
+    steam_user_id = response_dict['steamid']
+    
+    if 'vacbanned' in response_dict and response_dict['publisherbanned']:
+        logger.info("User is VAC Banned", steam_user_id=steam_user_id)
+        return None
+    
+    if 'publisherbanned' in response_dict and response_dict['publisherbanned']:
+        logger.info("User is Published Banned", steam_user_id=steam_user_id)
+        return None
+    
+    return steam_user_id
+
+
 # define a lambda function that returns a user_id
 @tracer.capture_lambda_handler
 def lambda_handler(event, context):
@@ -178,24 +216,18 @@ def lambda_handler(event, context):
             #logger.info("Received Steam auth token: ", steam_auth_token=steam_auth_token)
             
             # Validate the Steam auth token, and get Steam user ID
-            steam_token_validation_response_dict = None
             steam_user_id = None
             try:
-                steam_ticket_validation_response = requests.get(steam_token_validation_api_endpoint, params={'key': steam_web_api_key,
-                                                                 'appid': os.environ['STEAM_APP_ID'], 'ticket': steam_auth_token})
-                #logger.info(steam_ticket_validation_response.content)
-                steam_token_validation_response_dict = steam_ticket_validation_response.json()
+                steam_user_id = check_steam_token(steam_auth_token)
                 
                 # Check if we received a valid success response from Steam
-                if 'params' in steam_token_validation_response_dict['response'] and 'ownersteamid' in steam_token_validation_response_dict['response']['params']:
-                    steam_user_id = steam_token_validation_response_dict['response']['params']['ownersteamid']
+                if steam_user_id:
                     logger.info("Received Steam user ID: ", steam_user_id=steam_user_id)
                 else:
                     return generate_error('Error: Failed to validate Steam token')
 
-
             except Exception as e:
-                print(e)
+                logger.error("exception in check_steam_token", error=e)
                 return generate_error('Error: Token validation error')
 
             if steam_user_id != None:

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,6 +114,7 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -267,6 +268,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -313,6 +315,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -393,6 +396,7 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
+          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
           "APPLE_APP_ID": appId,
@@ -453,6 +457,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -523,6 +528,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -592,6 +598,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
         "FACEBOOK_APP_ID" : appId,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -104,7 +104,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -257,7 +257,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -303,7 +303,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -383,7 +383,7 @@ export class CustomIdentityComponentStack extends Stack {
             image: lambda.Runtime.PYTHON_3_11.bundlingImage,
             command: [
               'bash', '-c',
-              'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+              'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
             ],
         },}),
         runtime: lambda.Runtime.PYTHON_3_11,
@@ -443,7 +443,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -513,7 +513,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -582,7 +582,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,7 +114,8 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -210,7 +211,7 @@ export class CustomIdentityComponentStack extends Stack {
     // Define an API Gateway for the authentication component public endpoint
     const logGroup = new logs.LogGroup(this, "CustomIdentityAPiAccessLogs");
     const api_gateway = new apigw.RestApi(this, 'ApiGateway', {
-      restApiName: 'CustomIdentityComponentApi',
+      restApiName: 'CustomIdentityComponent',
       description: 'Custom Identity Component API',
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),
@@ -268,7 +269,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -315,7 +317,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -396,7 +399,8 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
-          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+          "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
           "APPLE_APP_ID": appId,
@@ -457,7 +461,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -528,7 +533,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -598,7 +604,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
         "FACEBOOK_APP_ID" : appId,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -4,7 +4,6 @@
 import { Stack, StackProps, CfnOutput, Duration } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import * as path from 'path';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
@@ -18,7 +17,6 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { NagSuppressions } from 'cdk-nag';
 import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
-import * as custom_resources from 'aws-cdk-lib/custom-resources'
 
 export interface CustomIdentityComponentStackProps extends StackProps {
   // If defined, login-with-apple endpoint will be created

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -7,7 +7,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import * as secretsmanager from  'aws-cdk-lib/aws-secretsmanager';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as events from 'aws-cdk-lib/aws-events';
@@ -42,7 +42,7 @@ export class CustomIdentityComponentStack extends Stack {
 
     // The shared policy for basic Lambda access needs for logging. This is similar to the managed Lambda Execution Policy
     const lambdaBasicPolicy = new iam.PolicyStatement({
-      actions: ['logs:CreateLogGroup','logs:CreateLogStream','logs:PutLogEvents'],
+      actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
       resources: ['*'],
     });
 
@@ -74,7 +74,7 @@ export class CustomIdentityComponentStack extends Stack {
 
     // Define a CloudFront distribution for the issuer data
     const distribution = new cloudfront.Distribution(this, 'IssuerEndpoint', {
-      defaultBehavior: { origin: new origins.S3Origin(issuer_bucket), cachePolicy: myCachePolicy},
+      defaultBehavior: { origin: new origins.S3Origin(issuer_bucket), cachePolicy: myCachePolicy },
       enableLogging: true,
       minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       logBucket: loggingBucket
@@ -84,7 +84,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Issuer endpoint used by customer backend components for validation JWT:s
-    new CfnOutput(this, 'IssuerEndpointUrl', { value: "https://"+distribution.domainName });
+    new CfnOutput(this, 'IssuerEndpointUrl', { value: "https://" + distribution.domainName });
 
     // Define a secrets manager secret with name jwk_private_key
     const secret = new secretsmanager.Secret(this, 'JWKPrivateKeySecret');
@@ -101,19 +101,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: generate_keys_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'generate_keys.lambda_handler',
       timeout: Duration.seconds(300),
       memorySize: 2048,
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
-        "ISSUER_ENDPOINT": "https://"+distribution.domainName,
+        "ISSUER_ENDPOINT": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -142,68 +143,68 @@ export class CustomIdentityComponentStack extends Stack {
     });
 
     // Define a Web Application Firewall with the standard AWS provided rule set
-    const cfnWebACLManaged = new wafv2.CfnWebACL(this,'CustomIdentityWebACL',{
-            defaultAction: {
-              allow: {}
-            },
-            scope: 'REGIONAL',
-            visibilityConfig: {
-              cloudWatchMetricsEnabled: true,
-              metricName:'MetricForWebACLCDK',
-              sampledRequestsEnabled: true,
-            },
-            name:'CustomIdentityWebACL',
-            rules: [{
-              name: 'ManagedWafRules',
-              priority: 0,
-              statement: {
-                managedRuleGroupStatement: {
-                  name:'AWSManagedRulesCommonRuleSet', // The standard rule set provided by AWS: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
-                  vendorName:'AWS'
-                }
-              },
-              visibilityConfig: {
-                cloudWatchMetricsEnabled: true,
-                metricName:'MetricForWebACLCDK-ManagedRules',
-                sampledRequestsEnabled: true,
-              },
-              overrideAction: {
-                none: {}
-              },
-            }]
-    });
-
-    const cfnWebACLRateLimit = new wafv2.CfnWebACL(this,'CustomIdentityWebACLRateLimit',{
+    const cfnWebACLManaged = new wafv2.CfnWebACL(this, 'CustomIdentityWebACL', {
       defaultAction: {
         allow: {}
       },
       scope: 'REGIONAL',
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
-        metricName:'MetricForWebACLCDKRateLimit',
+        metricName: 'MetricForWebACLCDK',
         sampledRequestsEnabled: true,
       },
-      name:'CustomIdentityWebACLRateLimit',
-      rules: [
-      // Add rate limiting rule to allow 3.33 TPS from a single IP (1000 per 5 minutes)
-      {
-        name: 'RateLimitingRule',
-        priority: 1,
-        action: {
-          block: {}
-        },
+      name: 'CustomIdentityWebACL',
+      rules: [{
+        name: 'ManagedWafRules',
+        priority: 0,
         statement: {
-          rateBasedStatement: {
-            limit: 1000,
-            aggregateKeyType: 'IP'
+          managedRuleGroupStatement: {
+            name: 'AWSManagedRulesCommonRuleSet', // The standard rule set provided by AWS: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
+            vendorName: 'AWS'
           }
         },
         visibilityConfig: {
           cloudWatchMetricsEnabled: true,
-          metricName:'MetricForWebACLCDK-RateLimiting',
+          metricName: 'MetricForWebACLCDK-ManagedRules',
           sampledRequestsEnabled: true,
-        }
+        },
+        overrideAction: {
+          none: {}
+        },
       }]
+    });
+
+    const cfnWebACLRateLimit = new wafv2.CfnWebACL(this, 'CustomIdentityWebACLRateLimit', {
+      defaultAction: {
+        allow: {}
+      },
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'MetricForWebACLCDKRateLimit',
+        sampledRequestsEnabled: true,
+      },
+      name: 'CustomIdentityWebACLRateLimit',
+      rules: [
+        // Add rate limiting rule to allow 3.33 TPS from a single IP (1000 per 5 minutes)
+        {
+          name: 'RateLimitingRule',
+          priority: 1,
+          action: {
+            block: {}
+          },
+          statement: {
+            rateBasedStatement: {
+              limit: 1000,
+              aggregateKeyType: 'IP'
+            }
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWebACLCDK-RateLimiting',
+            sampledRequestsEnabled: true,
+          }
+        }]
     });
 
     // Define an API Gateway for the authentication component public endpoint
@@ -214,27 +215,27 @@ export class CustomIdentityComponentStack extends Stack {
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),
         accessLogFormat: apigw.AccessLogFormat.clf(),
-        loggingLevel : MethodLoggingLevel.ERROR,
+        loggingLevel: MethodLoggingLevel.ERROR,
         tracingEnabled: true,
         stageName: 'prod',
       }
     });
     // cdk-nag suppression for the API Gateway default logs access
     NagSuppressions.addResourceSuppressions(
-      api_gateway,[{
-          id: 'AwsSolutions-IAM4',
-          reason: "We are using the default CW Logs access of API Gateway",
-        },],true);
+      api_gateway, [{
+        id: 'AwsSolutions-IAM4',
+        reason: "We are using the default CW Logs access of API Gateway",
+      },], true);
 
     // Attach the Web Application Firewall with the standard AWS provided rule set
-    new wafv2.CfnWebACLAssociation(this,'ApiGatewayWebACLAssociation',{
+    new wafv2.CfnWebACLAssociation(this, 'ApiGatewayWebACLAssociation', {
       resourceArn: api_gateway.deploymentStage.stageArn,
-      webAclArn:cfnWebACLManaged.attrArn,
+      webAclArn: cfnWebACLManaged.attrArn,
     });
     // Attach the WAF with the rate limit rules
-    new wafv2.CfnWebACLAssociation(this,'ApiGatewayWebACLAssociationRateLimit',{
+    new wafv2.CfnWebACLAssociation(this, 'ApiGatewayWebACLAssociationRateLimit', {
       resourceArn: api_gateway.deploymentStage.stageArn,
-      webAclArn:cfnWebACLRateLimit.attrArn,
+      webAclArn: cfnWebACLRateLimit.attrArn,
     });
 
     // Request validator for the API
@@ -254,19 +255,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: login_as_guest_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_as_guest.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -279,7 +281,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-as-guest').addMethod('GET', new apigw.LambdaIntegration(login_as_guest_function),{
+    api_gateway.root.addResource('login-as-guest').addMethod('GET', new apigw.LambdaIntegration(login_as_guest_function), {
       requestParameters: {
         'method.request.querystring.user_id': false,
         'method.request.querystring.guest_secret': false,
@@ -300,19 +302,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: refresh_access_token_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'refresh_access_token.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -323,9 +326,9 @@ export class CustomIdentityComponentStack extends Stack {
     NagSuppressions.addResourceSuppressions(refresh_access_token_function_role, [
       { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
     ], true);
-    
+
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('refresh-access-token').addMethod('GET', new apigw.LambdaIntegration(refresh_access_token_function),{
+    api_gateway.root.addResource('refresh-access-token').addMethod('GET', new apigw.LambdaIntegration(refresh_access_token_function), {
       requestParameters: {
         'method.request.querystring.refresh_token': true
       },
@@ -336,91 +339,92 @@ export class CustomIdentityComponentStack extends Stack {
     new CfnOutput(this, 'LoginEndpoint', { value: api_gateway.url });
 
     // If Apple ID App ID Defined, add a DynamoDB table and Lambda function for Apple login
-    if(props.appleIdAppId != "") {
-        this.setupAppleIdLogin(props.appleIdAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.appleIdAppId != "") {
+      this.setupAppleIdLogin(props.appleIdAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Steam App ID defined, add a DynamoDB table and Lambda function for Steam login
-    if(props.steamAppId != "") {
-        this.setupSteamLogin(props.steamAppId, props.steamWebApiKeySecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.steamAppId != "") {
+      this.setupSteamLogin(props.steamAppId, props.steamWebApiKeySecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Google Play App ID defined, add a DynamoDB table and Lambda function for Google Play login
-    if(props.googlePlayClientId != "") {
-        this.setupGooglePlayLogin(props.googlePlayClientId, props.googlePlayAppId, props.googlePlayClientSecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.googlePlayClientId != "") {
+      this.setupGooglePlayLogin(props.googlePlayClientId, props.googlePlayAppId, props.googlePlayClientSecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Facebook App ID defined, add a DynamoDB table and Lambda function for Facebook login
-    if(props.facebookAppId != "") {
-        this.setupFacebookLogin(props.facebookAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.facebookAppId != "") {
+      this.setupFacebookLogin(props.facebookAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
   }
 
   ///// *** IDENTITY PROVIDER SPECIFIC RESOURECE **** //////
 
   // Sets up Lambda endpoint and DynamoDB table for Apple ID Login
-  setupAppleIdLogin(appId : string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-    
-      // Define a DynamoDB table for AppleIdUsers
-      const appleIdUserTable = new dynamodb.Table(this, 'AppleIdUserTable', {
-        partitionKey: {
-          name: 'AppleId',
-          type: dynamodb.AttributeType.STRING
-        },
-        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-        pointInTimeRecovery: true
-      });
- 
-      // Lambda function for Apple Id login
-      const loginWithAppleIdFunctionRole = new iam.Role(this, 'LoginWithAppleIdFunctionRole', {
-        assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      });
-      loginWithAppleIdFunctionRole.addToPolicy(lambdaBasicPolicy);
-      const loginWithAppleIdFunction = new lambda.Function(this, 'LoginWithAppleId', {
-        role: loginWithAppleIdFunctionRole,
-        code: lambda.Code.fromAsset("lambda", {
-          bundling: {
-            image: lambda.Runtime.PYTHON_3_10.bundlingImage,
-            command: [
-              'bash', '-c',
-              'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
-            ],
-        },}),
-        runtime: lambda.Runtime.PYTHON_3_10,
-        handler: 'login_with_apple_id.lambda_handler',
-        timeout: Duration.seconds(15),
-        tracing: lambda.Tracing.ACTIVE,
-        memorySize: 2048,
-        environment: {
-          "ISSUER_URL": "https://"+distribution.domainName,
-          "SECRET_KEY_ID": secret.secretName,
-          "USER_TABLE": user_table.tableName,
-          "APPLE_APP_ID": appId,
-          "APPLE_ID_USER_TABLE": appleIdUserTable.tableName
-        }
-      });
-      secret.grantRead(loginWithAppleIdFunction);
-      user_table.grantReadWriteData(loginWithAppleIdFunction);
-      appleIdUserTable.grantReadWriteData(loginWithAppleIdFunction);
+  setupAppleIdLogin(appId: string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
 
-      NagSuppressions.addResourceSuppressions(loginWithAppleIdFunctionRole, [
-        { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
-      ], true);
+    // Define a DynamoDB table for AppleIdUsers
+    const appleIdUserTable = new dynamodb.Table(this, 'AppleIdUserTable', {
+      partitionKey: {
+        name: 'AppleId',
+        type: dynamodb.AttributeType.STRING
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true
+    });
 
-      // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-      api_gateway.root.addResource('login-with-apple-id').addMethod('GET', new apigw.LambdaIntegration(loginWithAppleIdFunction),{
-        requestParameters: {
-          'method.request.querystring.apple_auth_token': true,
-          'method.request.querystring.auth_token': false,
-          'method.request.querystring.link_to_existing_user': false
+    // Lambda function for Apple Id login
+    const loginWithAppleIdFunctionRole = new iam.Role(this, 'LoginWithAppleIdFunctionRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    loginWithAppleIdFunctionRole.addToPolicy(lambdaBasicPolicy);
+    const loginWithAppleIdFunction = new lambda.Function(this, 'LoginWithAppleId', {
+      role: loginWithAppleIdFunctionRole,
+      code: lambda.Code.fromAsset("lambda", {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          command: [
+            'bash', '-c',
+            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+          ],
         },
-        requestValidator: requestValidator
-      });
+      }),
+      runtime: lambda.Runtime.PYTHON_3_10,
+      handler: 'login_with_apple_id.lambda_handler',
+      timeout: Duration.seconds(15),
+      tracing: lambda.Tracing.ACTIVE,
+      memorySize: 2048,
+      environment: {
+        "ISSUER_URL": "https://" + distribution.domainName,
+        "SECRET_KEY_ID": secret.secretName,
+        "USER_TABLE": user_table.tableName,
+        "APPLE_APP_ID": appId,
+        "APPLE_ID_USER_TABLE": appleIdUserTable.tableName
+      }
+    });
+    secret.grantRead(loginWithAppleIdFunction);
+    user_table.grantReadWriteData(loginWithAppleIdFunction);
+    appleIdUserTable.grantReadWriteData(loginWithAppleIdFunction);
+
+    NagSuppressions.addResourceSuppressions(loginWithAppleIdFunctionRole, [
+      { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
+    ], true);
+
+    // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
+    api_gateway.root.addResource('login-with-apple-id').addMethod('GET', new apigw.LambdaIntegration(loginWithAppleIdFunction), {
+      requestParameters: {
+        'method.request.querystring.apple_auth_token': true,
+        'method.request.querystring.auth_token': false,
+        'method.request.querystring.link_to_existing_user': false
+      },
+      requestValidator: requestValidator
+    });
   }
 
   // Sets up Lambda endpoint and DynamoDB table for Steam ID Login
   setupSteamLogin(appId: string, steamWebApiKeySecretArn: string, privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-  
+
     // Define a DynamoDB table for Steam Users
     const steamIdUserTable = new dynamodb.Table(this, 'SteamUserTable', {
       partitionKey: {
@@ -440,19 +444,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithSteamIdFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_steam.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -476,7 +481,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-steam').addMethod('GET', new apigw.LambdaIntegration(loginWithSteamIdFunction),{
+    api_gateway.root.addResource('login-with-steam').addMethod('GET', new apigw.LambdaIntegration(loginWithSteamIdFunction), {
       requestParameters: {
         'method.request.querystring.steam_auth_token': true,
         'method.request.querystring.auth_token': false,
@@ -488,8 +493,8 @@ export class CustomIdentityComponentStack extends Stack {
 
   // Sets up Lambda endpoint and DynamoDB table for Google Play Login
   setupGooglePlayLogin(googlePlayClientId: string, googlePlayAppId: string, googlePlayClientSecretArn: string,
-                        privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table,
-                        distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
+    privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table,
+    distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
 
     // Define a DynamoDB table for Google Play
     const googlePlayUserTable = new dynamodb.Table(this, 'GooglePlayUserTable', {
@@ -507,22 +512,23 @@ export class CustomIdentityComponentStack extends Stack {
     });
     loginWithGooglePlayFunctionRole.addToPolicy(lambdaBasicPolicy);
     const loginWithGooglePlayFunction = new lambda.Function(this, 'LoginWithGooglePlay', {
-      role:  loginWithGooglePlayFunctionRole,
+      role: loginWithGooglePlayFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_google_play.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -547,7 +553,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-google-play').addMethod('GET', new apigw.LambdaIntegration(loginWithGooglePlayFunction),{
+    api_gateway.root.addResource('login-with-google-play').addMethod('GET', new apigw.LambdaIntegration(loginWithGooglePlayFunction), {
       requestParameters: {
         'method.request.querystring.google_play_auth_token': true,
         'method.request.querystring.auth_token': false,
@@ -557,9 +563,9 @@ export class CustomIdentityComponentStack extends Stack {
     });
   }
 
-   // Sets up Lambda endpoint and DynamoDB table for Facebook Login
-   setupFacebookLogin(appId : string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-    
+  // Sets up Lambda endpoint and DynamoDB table for Facebook Login
+  setupFacebookLogin(appId: string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
+
     // Define a DynamoDB table for Facebook Users
     const facebookUserTable = new dynamodb.Table(this, 'FacebookUserTable', {
       partitionKey: {
@@ -579,22 +585,23 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithFacebookFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_facebook.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
-        "FACEBOOK_APP_ID" : appId,
+        "FACEBOOK_APP_ID": appId,
         "FACEBOOK_USER_TABLE": facebookUserTable.tableName
       }
     });
@@ -607,7 +614,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-facebook').addMethod('GET', new apigw.LambdaIntegration(loginWithFacebookFunction),{
+    api_gateway.root.addResource('login-with-facebook').addMethod('GET', new apigw.LambdaIntegration(loginWithFacebookFunction), {
       requestParameters: {
         'method.request.querystring.facebook_access_token': true,
         'method.request.querystring.facebook_user_id': true,
@@ -616,5 +623,5 @@ export class CustomIdentityComponentStack extends Stack {
       },
       requestValidator: requestValidator
     });
-}
+  }
 };

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -211,7 +211,7 @@ export class CustomIdentityComponentStack extends Stack {
     // Define an API Gateway for the authentication component public endpoint
     const logGroup = new logs.LogGroup(this, "CustomIdentityAPiAccessLogs");
     const api_gateway = new apigw.RestApi(this, 'ApiGateway', {
-      restApiName: 'CustomIdentityComponent',
+      restApiName: 'CustomIdentityComponentApi',
       description: 'Custom Identity Component API',
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -101,13 +101,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: generate_keys_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'generate_keys.lambda_handler',
       timeout: Duration.seconds(300),
       memorySize: 2048,
@@ -254,13 +254,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: login_as_guest_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_as_guest.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -300,13 +300,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: refresh_access_token_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'refresh_access_token.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -380,13 +380,13 @@ export class CustomIdentityComponentStack extends Stack {
         role: loginWithAppleIdFunctionRole,
         code: lambda.Code.fromAsset("lambda", {
           bundling: {
-            image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+            image: lambda.Runtime.PYTHON_3_11.bundlingImage,
             command: [
               'bash', '-c',
               'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
             ],
         },}),
-        runtime: lambda.Runtime.PYTHON_3_10,
+        runtime: lambda.Runtime.PYTHON_3_11,
         handler: 'login_with_apple_id.lambda_handler',
         timeout: Duration.seconds(15),
         tracing: lambda.Tracing.ACTIVE,
@@ -440,13 +440,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithSteamIdFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_steam.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -510,13 +510,13 @@ export class CustomIdentityComponentStack extends Stack {
       role:  loginWithGooglePlayFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_google_play.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -579,13 +579,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithFacebookFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_facebook.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,


### PR DESCRIPTION
- Updated to Python 3.11.  As part of this platform was updated from manylinux2010_x86_64 to manylinux2014_x86_64, otherwise pip pulls in a very old (1.x) version of pyjwt, likely due to an ffi dependency.
- Set POWERTOOLS_SERVICE_NAME so tracing doesn't report service_undefined

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
