### PR TITLE
Update to Python 3.11 and set POWERTOOLS_SERVICE_NAME for Python Lambda functions 

### DIFF
--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,6 +114,7 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -267,6 +268,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -313,6 +315,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -393,6 +396,7 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
+          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
           "APPLE_APP_ID": appId,
@@ -453,6 +457,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -523,6 +528,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -592,6 +598,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
         "FACEBOOK_APP_ID" : appId,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -104,7 +104,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -257,7 +257,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -303,7 +303,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -383,7 +383,7 @@ export class CustomIdentityComponentStack extends Stack {
             image: lambda.Runtime.PYTHON_3_11.bundlingImage,
             command: [
               'bash', '-c',
-              'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+              'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
             ],
         },}),
         runtime: lambda.Runtime.PYTHON_3_11,
@@ -443,7 +443,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -513,7 +513,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,
@@ -582,7 +582,7 @@ export class CustomIdentityComponentStack extends Stack {
           image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
-            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+            'pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
       runtime: lambda.Runtime.PYTHON_3_11,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -7,7 +7,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
-import * as secretsmanager from  'aws-cdk-lib/aws-secretsmanager';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as events from 'aws-cdk-lib/aws-events';
@@ -42,7 +42,7 @@ export class CustomIdentityComponentStack extends Stack {
 
     // The shared policy for basic Lambda access needs for logging. This is similar to the managed Lambda Execution Policy
     const lambdaBasicPolicy = new iam.PolicyStatement({
-      actions: ['logs:CreateLogGroup','logs:CreateLogStream','logs:PutLogEvents'],
+      actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
       resources: ['*'],
     });
 
@@ -74,7 +74,7 @@ export class CustomIdentityComponentStack extends Stack {
 
     // Define a CloudFront distribution for the issuer data
     const distribution = new cloudfront.Distribution(this, 'IssuerEndpoint', {
-      defaultBehavior: { origin: new origins.S3Origin(issuer_bucket), cachePolicy: myCachePolicy},
+      defaultBehavior: { origin: new origins.S3Origin(issuer_bucket), cachePolicy: myCachePolicy },
       enableLogging: true,
       minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
       logBucket: loggingBucket
@@ -84,7 +84,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Issuer endpoint used by customer backend components for validation JWT:s
-    new CfnOutput(this, 'IssuerEndpointUrl', { value: "https://"+distribution.domainName });
+    new CfnOutput(this, 'IssuerEndpointUrl', { value: "https://" + distribution.domainName });
 
     // Define a secrets manager secret with name jwk_private_key
     const secret = new secretsmanager.Secret(this, 'JWKPrivateKeySecret');
@@ -101,19 +101,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: generate_keys_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'generate_keys.lambda_handler',
       timeout: Duration.seconds(300),
       memorySize: 2048,
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
-        "ISSUER_ENDPOINT": "https://"+distribution.domainName,
+        "ISSUER_ENDPOINT": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -142,68 +143,68 @@ export class CustomIdentityComponentStack extends Stack {
     });
 
     // Define a Web Application Firewall with the standard AWS provided rule set
-    const cfnWebACLManaged = new wafv2.CfnWebACL(this,'CustomIdentityWebACL',{
-            defaultAction: {
-              allow: {}
-            },
-            scope: 'REGIONAL',
-            visibilityConfig: {
-              cloudWatchMetricsEnabled: true,
-              metricName:'MetricForWebACLCDK',
-              sampledRequestsEnabled: true,
-            },
-            name:'CustomIdentityWebACL',
-            rules: [{
-              name: 'ManagedWafRules',
-              priority: 0,
-              statement: {
-                managedRuleGroupStatement: {
-                  name:'AWSManagedRulesCommonRuleSet', // The standard rule set provided by AWS: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
-                  vendorName:'AWS'
-                }
-              },
-              visibilityConfig: {
-                cloudWatchMetricsEnabled: true,
-                metricName:'MetricForWebACLCDK-ManagedRules',
-                sampledRequestsEnabled: true,
-              },
-              overrideAction: {
-                none: {}
-              },
-            }]
-    });
-
-    const cfnWebACLRateLimit = new wafv2.CfnWebACL(this,'CustomIdentityWebACLRateLimit',{
+    const cfnWebACLManaged = new wafv2.CfnWebACL(this, 'CustomIdentityWebACL', {
       defaultAction: {
         allow: {}
       },
       scope: 'REGIONAL',
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
-        metricName:'MetricForWebACLCDKRateLimit',
+        metricName: 'MetricForWebACLCDK',
         sampledRequestsEnabled: true,
       },
-      name:'CustomIdentityWebACLRateLimit',
-      rules: [
-      // Add rate limiting rule to allow 3.33 TPS from a single IP (1000 per 5 minutes)
-      {
-        name: 'RateLimitingRule',
-        priority: 1,
-        action: {
-          block: {}
-        },
+      name: 'CustomIdentityWebACL',
+      rules: [{
+        name: 'ManagedWafRules',
+        priority: 0,
         statement: {
-          rateBasedStatement: {
-            limit: 1000,
-            aggregateKeyType: 'IP'
+          managedRuleGroupStatement: {
+            name: 'AWSManagedRulesCommonRuleSet', // The standard rule set provided by AWS: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html
+            vendorName: 'AWS'
           }
         },
         visibilityConfig: {
           cloudWatchMetricsEnabled: true,
-          metricName:'MetricForWebACLCDK-RateLimiting',
+          metricName: 'MetricForWebACLCDK-ManagedRules',
           sampledRequestsEnabled: true,
-        }
+        },
+        overrideAction: {
+          none: {}
+        },
       }]
+    });
+
+    const cfnWebACLRateLimit = new wafv2.CfnWebACL(this, 'CustomIdentityWebACLRateLimit', {
+      defaultAction: {
+        allow: {}
+      },
+      scope: 'REGIONAL',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'MetricForWebACLCDKRateLimit',
+        sampledRequestsEnabled: true,
+      },
+      name: 'CustomIdentityWebACLRateLimit',
+      rules: [
+        // Add rate limiting rule to allow 3.33 TPS from a single IP (1000 per 5 minutes)
+        {
+          name: 'RateLimitingRule',
+          priority: 1,
+          action: {
+            block: {}
+          },
+          statement: {
+            rateBasedStatement: {
+              limit: 1000,
+              aggregateKeyType: 'IP'
+            }
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'MetricForWebACLCDK-RateLimiting',
+            sampledRequestsEnabled: true,
+          }
+        }]
     });
 
     // Define an API Gateway for the authentication component public endpoint
@@ -214,27 +215,27 @@ export class CustomIdentityComponentStack extends Stack {
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),
         accessLogFormat: apigw.AccessLogFormat.clf(),
-        loggingLevel : MethodLoggingLevel.ERROR,
+        loggingLevel: MethodLoggingLevel.ERROR,
         tracingEnabled: true,
         stageName: 'prod',
       }
     });
     // cdk-nag suppression for the API Gateway default logs access
     NagSuppressions.addResourceSuppressions(
-      api_gateway,[{
-          id: 'AwsSolutions-IAM4',
-          reason: "We are using the default CW Logs access of API Gateway",
-        },],true);
+      api_gateway, [{
+        id: 'AwsSolutions-IAM4',
+        reason: "We are using the default CW Logs access of API Gateway",
+      },], true);
 
     // Attach the Web Application Firewall with the standard AWS provided rule set
-    new wafv2.CfnWebACLAssociation(this,'ApiGatewayWebACLAssociation',{
+    new wafv2.CfnWebACLAssociation(this, 'ApiGatewayWebACLAssociation', {
       resourceArn: api_gateway.deploymentStage.stageArn,
-      webAclArn:cfnWebACLManaged.attrArn,
+      webAclArn: cfnWebACLManaged.attrArn,
     });
     // Attach the WAF with the rate limit rules
-    new wafv2.CfnWebACLAssociation(this,'ApiGatewayWebACLAssociationRateLimit',{
+    new wafv2.CfnWebACLAssociation(this, 'ApiGatewayWebACLAssociationRateLimit', {
       resourceArn: api_gateway.deploymentStage.stageArn,
-      webAclArn:cfnWebACLRateLimit.attrArn,
+      webAclArn: cfnWebACLRateLimit.attrArn,
     });
 
     // Request validator for the API
@@ -254,19 +255,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: login_as_guest_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_as_guest.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -279,7 +281,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-as-guest').addMethod('GET', new apigw.LambdaIntegration(login_as_guest_function),{
+    api_gateway.root.addResource('login-as-guest').addMethod('GET', new apigw.LambdaIntegration(login_as_guest_function), {
       requestParameters: {
         'method.request.querystring.user_id': false,
         'method.request.querystring.guest_secret': false,
@@ -300,19 +302,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: refresh_access_token_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'refresh_access_token.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -323,9 +326,9 @@ export class CustomIdentityComponentStack extends Stack {
     NagSuppressions.addResourceSuppressions(refresh_access_token_function_role, [
       { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
     ], true);
-    
+
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('refresh-access-token').addMethod('GET', new apigw.LambdaIntegration(refresh_access_token_function),{
+    api_gateway.root.addResource('refresh-access-token').addMethod('GET', new apigw.LambdaIntegration(refresh_access_token_function), {
       requestParameters: {
         'method.request.querystring.refresh_token': true
       },
@@ -336,91 +339,92 @@ export class CustomIdentityComponentStack extends Stack {
     new CfnOutput(this, 'LoginEndpoint', { value: api_gateway.url });
 
     // If Apple ID App ID Defined, add a DynamoDB table and Lambda function for Apple login
-    if(props.appleIdAppId != "") {
-        this.setupAppleIdLogin(props.appleIdAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.appleIdAppId != "") {
+      this.setupAppleIdLogin(props.appleIdAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Steam App ID defined, add a DynamoDB table and Lambda function for Steam login
-    if(props.steamAppId != "") {
-        this.setupSteamLogin(props.steamAppId, props.steamWebApiKeySecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.steamAppId != "") {
+      this.setupSteamLogin(props.steamAppId, props.steamWebApiKeySecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Google Play App ID defined, add a DynamoDB table and Lambda function for Google Play login
-    if(props.googlePlayClientId != "") {
-        this.setupGooglePlayLogin(props.googlePlayClientId, props.googlePlayAppId, props.googlePlayClientSecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.googlePlayClientId != "") {
+      this.setupGooglePlayLogin(props.googlePlayClientId, props.googlePlayAppId, props.googlePlayClientSecretArn, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
 
     // If Facebook App ID defined, add a DynamoDB table and Lambda function for Facebook login
-    if(props.facebookAppId != "") {
-        this.setupFacebookLogin(props.facebookAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
+    if (props.facebookAppId != "") {
+      this.setupFacebookLogin(props.facebookAppId, secret, user_table, distribution, api_gateway, lambdaBasicPolicy, requestValidator);
     }
   }
 
   ///// *** IDENTITY PROVIDER SPECIFIC RESOURECE **** //////
 
   // Sets up Lambda endpoint and DynamoDB table for Apple ID Login
-  setupAppleIdLogin(appId : string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-    
-      // Define a DynamoDB table for AppleIdUsers
-      const appleIdUserTable = new dynamodb.Table(this, 'AppleIdUserTable', {
-        partitionKey: {
-          name: 'AppleId',
-          type: dynamodb.AttributeType.STRING
-        },
-        billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-        pointInTimeRecovery: true
-      });
- 
-      // Lambda function for Apple Id login
-      const loginWithAppleIdFunctionRole = new iam.Role(this, 'LoginWithAppleIdFunctionRole', {
-        assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      });
-      loginWithAppleIdFunctionRole.addToPolicy(lambdaBasicPolicy);
-      const loginWithAppleIdFunction = new lambda.Function(this, 'LoginWithAppleId', {
-        role: loginWithAppleIdFunctionRole,
-        code: lambda.Code.fromAsset("lambda", {
-          bundling: {
-            image: lambda.Runtime.PYTHON_3_10.bundlingImage,
-            command: [
-              'bash', '-c',
-              'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
-            ],
-        },}),
-        runtime: lambda.Runtime.PYTHON_3_10,
-        handler: 'login_with_apple_id.lambda_handler',
-        timeout: Duration.seconds(15),
-        tracing: lambda.Tracing.ACTIVE,
-        memorySize: 2048,
-        environment: {
-          "ISSUER_URL": "https://"+distribution.domainName,
-          "SECRET_KEY_ID": secret.secretName,
-          "USER_TABLE": user_table.tableName,
-          "APPLE_APP_ID": appId,
-          "APPLE_ID_USER_TABLE": appleIdUserTable.tableName
-        }
-      });
-      secret.grantRead(loginWithAppleIdFunction);
-      user_table.grantReadWriteData(loginWithAppleIdFunction);
-      appleIdUserTable.grantReadWriteData(loginWithAppleIdFunction);
+  setupAppleIdLogin(appId: string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
 
-      NagSuppressions.addResourceSuppressions(loginWithAppleIdFunctionRole, [
-        { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
-      ], true);
+    // Define a DynamoDB table for AppleIdUsers
+    const appleIdUserTable = new dynamodb.Table(this, 'AppleIdUserTable', {
+      partitionKey: {
+        name: 'AppleId',
+        type: dynamodb.AttributeType.STRING
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: true
+    });
 
-      // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-      api_gateway.root.addResource('login-with-apple-id').addMethod('GET', new apigw.LambdaIntegration(loginWithAppleIdFunction),{
-        requestParameters: {
-          'method.request.querystring.apple_auth_token': true,
-          'method.request.querystring.auth_token': false,
-          'method.request.querystring.link_to_existing_user': false
+    // Lambda function for Apple Id login
+    const loginWithAppleIdFunctionRole = new iam.Role(this, 'LoginWithAppleIdFunctionRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+    loginWithAppleIdFunctionRole.addToPolicy(lambdaBasicPolicy);
+    const loginWithAppleIdFunction = new lambda.Function(this, 'LoginWithAppleId', {
+      role: loginWithAppleIdFunctionRole,
+      code: lambda.Code.fromAsset("lambda", {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          command: [
+            'bash', '-c',
+            'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
+          ],
         },
-        requestValidator: requestValidator
-      });
+      }),
+      runtime: lambda.Runtime.PYTHON_3_10,
+      handler: 'login_with_apple_id.lambda_handler',
+      timeout: Duration.seconds(15),
+      tracing: lambda.Tracing.ACTIVE,
+      memorySize: 2048,
+      environment: {
+        "ISSUER_URL": "https://" + distribution.domainName,
+        "SECRET_KEY_ID": secret.secretName,
+        "USER_TABLE": user_table.tableName,
+        "APPLE_APP_ID": appId,
+        "APPLE_ID_USER_TABLE": appleIdUserTable.tableName
+      }
+    });
+    secret.grantRead(loginWithAppleIdFunction);
+    user_table.grantReadWriteData(loginWithAppleIdFunction);
+    appleIdUserTable.grantReadWriteData(loginWithAppleIdFunction);
+
+    NagSuppressions.addResourceSuppressions(loginWithAppleIdFunctionRole, [
+      { id: 'AwsSolutions-IAM5', reason: 'Using the standard Lambda execution role, all custom access resource restricted.' }
+    ], true);
+
+    // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
+    api_gateway.root.addResource('login-with-apple-id').addMethod('GET', new apigw.LambdaIntegration(loginWithAppleIdFunction), {
+      requestParameters: {
+        'method.request.querystring.apple_auth_token': true,
+        'method.request.querystring.auth_token': false,
+        'method.request.querystring.link_to_existing_user': false
+      },
+      requestValidator: requestValidator
+    });
   }
 
   // Sets up Lambda endpoint and DynamoDB table for Steam ID Login
   setupSteamLogin(appId: string, steamWebApiKeySecretArn: string, privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-  
+
     // Define a DynamoDB table for Steam Users
     const steamIdUserTable = new dynamodb.Table(this, 'SteamUserTable', {
       partitionKey: {
@@ -440,19 +444,20 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithSteamIdFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_steam.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -476,7 +481,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-steam').addMethod('GET', new apigw.LambdaIntegration(loginWithSteamIdFunction),{
+    api_gateway.root.addResource('login-with-steam').addMethod('GET', new apigw.LambdaIntegration(loginWithSteamIdFunction), {
       requestParameters: {
         'method.request.querystring.steam_auth_token': true,
         'method.request.querystring.auth_token': false,
@@ -488,8 +493,8 @@ export class CustomIdentityComponentStack extends Stack {
 
   // Sets up Lambda endpoint and DynamoDB table for Google Play Login
   setupGooglePlayLogin(googlePlayClientId: string, googlePlayAppId: string, googlePlayClientSecretArn: string,
-                        privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table,
-                        distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
+    privateKeySecret: secretsmanager.Secret, user_table: dynamodb.Table,
+    distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
 
     // Define a DynamoDB table for Google Play
     const googlePlayUserTable = new dynamodb.Table(this, 'GooglePlayUserTable', {
@@ -507,22 +512,23 @@ export class CustomIdentityComponentStack extends Stack {
     });
     loginWithGooglePlayFunctionRole.addToPolicy(lambdaBasicPolicy);
     const loginWithGooglePlayFunction = new lambda.Function(this, 'LoginWithGooglePlay', {
-      role:  loginWithGooglePlayFunctionRole,
+      role: loginWithGooglePlayFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_google_play.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -547,7 +553,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-google-play').addMethod('GET', new apigw.LambdaIntegration(loginWithGooglePlayFunction),{
+    api_gateway.root.addResource('login-with-google-play').addMethod('GET', new apigw.LambdaIntegration(loginWithGooglePlayFunction), {
       requestParameters: {
         'method.request.querystring.google_play_auth_token': true,
         'method.request.querystring.auth_token': false,
@@ -557,9 +563,9 @@ export class CustomIdentityComponentStack extends Stack {
     });
   }
 
-   // Sets up Lambda endpoint and DynamoDB table for Facebook Login
-   setupFacebookLogin(appId : string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
-    
+  // Sets up Lambda endpoint and DynamoDB table for Facebook Login
+  setupFacebookLogin(appId: string, secret: secretsmanager.Secret, user_table: dynamodb.Table, distribution: cloudfront.Distribution, api_gateway: apigw.RestApi, lambdaBasicPolicy: iam.PolicyStatement, requestValidator: apigw.RequestValidator) {
+
     // Define a DynamoDB table for Facebook Users
     const facebookUserTable = new dynamodb.Table(this, 'FacebookUserTable', {
       partitionKey: {
@@ -579,22 +585,23 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithFacebookFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
-      },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+        },
+      }),
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_facebook.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
       memorySize: 2048,
       environment: {
-        "ISSUER_URL": "https://"+distribution.domainName,
+        "ISSUER_URL": "https://" + distribution.domainName,
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
-        "FACEBOOK_APP_ID" : appId,
+        "FACEBOOK_APP_ID": appId,
         "FACEBOOK_USER_TABLE": facebookUserTable.tableName
       }
     });
@@ -607,7 +614,7 @@ export class CustomIdentityComponentStack extends Stack {
     ], true);
 
     // Map login_as_guest_function to the api_gateway GET requeste login_as_guest
-    api_gateway.root.addResource('login-with-facebook').addMethod('GET', new apigw.LambdaIntegration(loginWithFacebookFunction),{
+    api_gateway.root.addResource('login-with-facebook').addMethod('GET', new apigw.LambdaIntegration(loginWithFacebookFunction), {
       requestParameters: {
         'method.request.querystring.facebook_access_token': true,
         'method.request.querystring.facebook_user_id': true,
@@ -616,5 +623,5 @@ export class CustomIdentityComponentStack extends Stack {
       },
       requestValidator: requestValidator
     });
-}
+  }
 };

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -101,13 +101,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: generate_keys_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'generate_keys.lambda_handler',
       timeout: Duration.seconds(300),
       memorySize: 2048,
@@ -254,13 +254,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: login_as_guest_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_as_guest.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -300,13 +300,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: refresh_access_token_function_role,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'refresh_access_token.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -380,13 +380,13 @@ export class CustomIdentityComponentStack extends Stack {
         role: loginWithAppleIdFunctionRole,
         code: lambda.Code.fromAsset("lambda", {
           bundling: {
-            image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+            image: lambda.Runtime.PYTHON_3_11.bundlingImage,
             command: [
               'bash', '-c',
               'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
             ],
         },}),
-        runtime: lambda.Runtime.PYTHON_3_10,
+        runtime: lambda.Runtime.PYTHON_3_11,
         handler: 'login_with_apple_id.lambda_handler',
         timeout: Duration.seconds(15),
         tracing: lambda.Tracing.ACTIVE,
@@ -440,13 +440,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithSteamIdFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_steam.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -510,13 +510,13 @@ export class CustomIdentityComponentStack extends Stack {
       role:  loginWithGooglePlayFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_google_play.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,
@@ -579,13 +579,13 @@ export class CustomIdentityComponentStack extends Stack {
       role: loginWithFacebookFunctionRole,
       code: lambda.Code.fromAsset("lambda", {
         bundling: {
-          image: lambda.Runtime.PYTHON_3_10.bundlingImage,
+          image: lambda.Runtime.PYTHON_3_11.bundlingImage,
           command: [
             'bash', '-c',
             'pip install --platform manylinux2010_x86_64 --only-binary=:all: -r requirements.txt -t /asset-output && cp -ru . /asset-output'
           ],
       },}),
-      runtime: lambda.Runtime.PYTHON_3_10,
+      runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'login_with_facebook.lambda_handler',
       timeout: Duration.seconds(15),
       tracing: lambda.Tracing.ACTIVE,

--- a/CustomIdentityComponent/package-lock.json
+++ b/CustomIdentityComponent/package-lock.json
@@ -8,7 +8,7 @@
       "name": "custom_identity_component",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.78.0",
+        "aws-cdk-lib": "^2.97.0",
         "cdk": "^2.81.0-alpha.0",
         "cdk-nag": "^2.27.24",
         "constructs": "^10.0.0",
@@ -41,19 +41,19 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.185",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.185.tgz",
-      "integrity": "sha512-cost0pu5nsmQmFhVxN4OonThGhgQeSlwntdXsEi5v8buVg+X4MzcXemmmSZxkkzzFCoS0r4w/7BiX1e+mMkFVA=="
+      "version": "2.2.200",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
+      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.155",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.155.tgz",
-      "integrity": "sha512-Q+Ny25hUPINlBbS6lmbUr4m6Tr6ToEJBla7sXA3FO3JUD0Z69ddcgbhuEBF8Rh1a2xmPONm89eX77kwK2fb4vQ=="
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.21.4",
@@ -1251,9 +1251,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.81.0.tgz",
-      "integrity": "sha512-jnXvyhyRvoFTQcpZPtZOeOyY7k4Jb1+c83RLFic71KrwL6xxLxzImbS5rnoDOJHaX/otyfDxzQfziOQ7I0kt/g==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.97.0.tgz",
+      "integrity": "sha512-O9LYiQcaJTngaz4wocMw6RIcPs7jhIXE1k+2uEBrf6UqaH/nxa18wd4q5Mw7+jNFLkR37Ivw6XF/RYA5ZcREKw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1267,9 +1267,9 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -1277,7 +1277,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -1493,7 +1493,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.1",
+      "version": "7.5.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3995,7 +3995,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4765,19 +4764,19 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.185",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.185.tgz",
-      "integrity": "sha512-cost0pu5nsmQmFhVxN4OonThGhgQeSlwntdXsEi5v8buVg+X4MzcXemmmSZxkkzzFCoS0r4w/7BiX1e+mMkFVA=="
+      "version": "2.2.200",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz",
+      "integrity": "sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg=="
     },
     "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
-      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
-    "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.155",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.155.tgz",
-      "integrity": "sha512-Q+Ny25hUPINlBbS6lmbUr4m6Tr6ToEJBla7sXA3FO3JUD0Z69ddcgbhuEBF8Rh1a2xmPONm89eX77kwK2fb4vQ=="
+    "@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
     "@babel/code-frame": {
       "version": "7.21.4",
@@ -5735,13 +5734,13 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.81.0.tgz",
-      "integrity": "sha512-jnXvyhyRvoFTQcpZPtZOeOyY7k4Jb1+c83RLFic71KrwL6xxLxzImbS5rnoDOJHaX/otyfDxzQfziOQ7I0kt/g==",
+      "version": "2.97.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.97.0.tgz",
+      "integrity": "sha512-O9LYiQcaJTngaz4wocMw6RIcPs7jhIXE1k+2uEBrf6UqaH/nxa18wd4q5Mw7+jNFLkR37Ivw6XF/RYA5ZcREKw==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.177",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.148",
+        "@aws-cdk/asset-awscli-v1": "^2.2.200",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.1.1",
@@ -5749,7 +5748,7 @@
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.0",
-        "semver": "^7.5.1",
+        "semver": "^7.5.4",
         "table": "^6.8.1",
         "yaml": "1.10.2"
       },
@@ -5886,7 +5885,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "7.5.1",
+          "version": "7.5.4",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7767,8 +7766,7 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/CustomIdentityComponent/package.json
+++ b/CustomIdentityComponent/package.json
@@ -20,7 +20,7 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.78.0",
+    "aws-cdk-lib": "^2.97.0",
     "cdk": "^2.81.0-alpha.0",
     "cdk-nag": "^2.27.24",
     "constructs": "^10.0.0",


### PR DESCRIPTION
Issue: https://github.com/aws-solutions-library-samples/guidance-for-custom-game-backend-hosting-on-aws/issues/7

- Updated to Python 3.11.  As part of this platform was updated from manylinux2010_x86_64 to manylinux2014_x86_64, otherwise pip pulls in a very old (1.x) version of pyjwt, likely due to an ffi dependency.
- Set POWERTOOLS_SERVICE_NAME so tracing doesn't report service_undefined


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
