### PR TITLE
Steam Auth Improvements

### DIFF
--- a/CustomIdentityComponent/lambda/login_with_steam.py
+++ b/CustomIdentityComponent/lambda/login_with_steam.py
@@ -3,9 +3,9 @@
 
 import boto3
 from botocore.config import Config
+import datetime
 import uuid
 import os
-import jwt
 from encryption_and_decryption import encrypt, decrypt
 import json
 import requests
@@ -18,7 +18,8 @@ logger = Logger()
 config = Config(connect_timeout=2, read_timeout=2)
 dynamodb = boto3.resource('dynamodb', config=config)
 
-steam_token_validation_api_endpoint = "https://api.steampowered.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
+# partner.steam-api.com is the server to server endpoint per https://partner.steamgames.com/doc/webapi_overview#3 
+steam_token_validation_api_endpoint = "https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1/"
 
 # Steam Web Api key from Secrets manager, cached between requests for 15 minutes
 steam_web_api_key = None
@@ -30,11 +31,11 @@ def refresh_steam_web_api_key_if_needed():
     # get time difference between current time and last_private_key_refresh
     current_time = int(time.time())
     time_difference = current_time - last_steam_web_api_key_refresh
-    print("Time difference between current time and last_steam_web_api_key_refresh: ", time_difference)
+    logger.debug("Time difference between current time and last_steam_web_api_key_refresh: ", time_difference)
 
     # check if we need to refresh the private key (every 30 minutes as this changes rarely if ever)
     if time_difference > 1800 or steam_web_api_key == None:
-        print("Refreshing Steam web api key")
+        logger.info("Refreshing Steam web api key")
 
         # get private key from AWS Secrets Manager
         secret_arn= os.environ['STEAM_WEB_API_KEY_SECRET_ARN']
@@ -100,13 +101,6 @@ def generate_success(user_id, steam_id, jwt_token, refresh_token, auth_token_exp
         "isBase64Encoded": False
     }
 
-@tracer.capture_method
-def find_key_with_kid(key_set, kid):
-    for key in key_set:
-        if key["kid"] == kid:
-            return jwt.algorithms.RSAAlgorithm.from_jwk(key)
-    return None
-
 # Tries to get an existing user from User Table. Reports error if request fails
 @tracer.capture_method
 def get_existing_user(steam_id):
@@ -132,7 +126,7 @@ def add_new_user_to_steam_table(user_id, steam_id):
         steam_id_user_table.put_item(
         Item={
             'UserId': user_id,
-            'SteamId': steam_id, # NOTE: You might want to add other information from the Steam API response too
+            'SteamId': steam_id,
         });
         return True
     except Exception as e:
@@ -161,6 +155,50 @@ def link_steam_id_to_existing_user(user_id, steam_id):
     
     return False
 
+def check_steam_token(token: str) -> str:
+    response = None
+    response_body = {}
+    while True:
+        send_time = datetime.datetime.utcnow()
+        response = requests.get(steam_token_validation_api_endpoint, 
+                                params={'key': steam_web_api_key, 'appid': os.environ['STEAM_APP_ID'], 'ticket': token})
+        elapsed_ms = round(((datetime.datetime.utcnow()-send_time).microseconds)/1000)
+        logger.debug(f'Steam response', elapsed_ms=elapsed_ms, code=response.status_code, headers=response.headers, body=response.text)
+        
+        if response.status_code != 200:
+            logger.error("Steam returned an error", response_code=response.status_code)
+            return None
+
+        response_body = response.json()
+
+        # retry on error code 103 after a second
+        if response_body.get('response', {}).get('error', {}).get('errorcode', 0) != 103:
+            break
+
+        logger.info("Received 103, retrying after a delay")
+        time.sleep(1)
+
+    response_dict = response_body.get('response', {}).get('params', {})
+    if not 'result' in response_dict or response_dict['result'] != 'OK':
+        logger.info("Result in not OK", result= response_dict['result'])
+        return None
+    
+    if not 'steamid' in response_dict:
+        logger.error("steamid missing", response=response_dict)
+        return None
+    steam_user_id = response_dict['steamid']
+    
+    if 'vacbanned' in response_dict and response_dict['publisherbanned']:
+        logger.info("User is VAC Banned", steam_user_id=steam_user_id)
+        return None
+    
+    if 'publisherbanned' in response_dict and response_dict['publisherbanned']:
+        logger.info("User is Published Banned", steam_user_id=steam_user_id)
+        return None
+    
+    return steam_user_id
+
+
 # define a lambda function that returns a user_id
 @tracer.capture_lambda_handler
 def lambda_handler(event, context):
@@ -178,24 +216,18 @@ def lambda_handler(event, context):
             #logger.info("Received Steam auth token: ", steam_auth_token=steam_auth_token)
             
             # Validate the Steam auth token, and get Steam user ID
-            steam_token_validation_response_dict = None
             steam_user_id = None
             try:
-                steam_ticket_validation_response = requests.get(steam_token_validation_api_endpoint, params={'key': steam_web_api_key,
-                                                                 'appid': os.environ['STEAM_APP_ID'], 'ticket': steam_auth_token})
-                #logger.info(steam_ticket_validation_response.content)
-                steam_token_validation_response_dict = steam_ticket_validation_response.json()
+                steam_user_id = check_steam_token(steam_auth_token)
                 
                 # Check if we received a valid success response from Steam
-                if 'params' in steam_token_validation_response_dict['response'] and 'ownersteamid' in steam_token_validation_response_dict['response']['params']:
-                    steam_user_id = steam_token_validation_response_dict['response']['params']['ownersteamid']
+                if steam_user_id:
                     logger.info("Received Steam user ID: ", steam_user_id=steam_user_id)
                 else:
                     return generate_error('Error: Failed to validate Steam token')
 
-
             except Exception as e:
-                print(e)
+                logger.error("exception in check_steam_token", error=e)
                 return generate_error('Error: Token validation error')
 
             if steam_user_id != None:

--- a/CustomIdentityComponent/lambda/login_with_steam.py
+++ b/CustomIdentityComponent/lambda/login_with_steam.py
@@ -161,6 +161,9 @@ def link_steam_id_to_existing_user(user_id, steam_id):
 def check_steam_token(token: str) -> str:
     response = None
     response_body = {}
+
+    # We will try validating the steam token if we get a 103 error (rare)
+    # Note: The Lambda function will time out in the very unlikely case of this error happening 15 times in a row
     while True:
         steam_web_api_key = parameters.get_secret(os.environ['STEAM_WEB_API_KEY_SECRET_ARN'], max_age=steam_web_api_secret_max_age)
         send_time = datetime.datetime.utcnow()

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,7 +114,7 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
       }
@@ -269,7 +269,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
@@ -317,7 +317,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
@@ -399,7 +399,7 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
-          "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+          "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
           "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
@@ -461,7 +461,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
@@ -533,7 +533,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
@@ -604,7 +604,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS for Games",
         "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,6 +114,7 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -267,6 +268,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -313,6 +315,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -393,6 +396,7 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
+          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
           "APPLE_APP_ID": appId,
@@ -453,6 +457,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -523,6 +528,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -592,6 +598,7 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
         "FACEBOOK_APP_ID" : appId,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -114,7 +114,8 @@ export class CustomIdentityComponentStack extends Stack {
       environment: {
         "ISSUER_BUCKET": issuer_bucket.bucketName,
         "ISSUER_ENDPOINT": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
       }
     });
@@ -210,7 +211,7 @@ export class CustomIdentityComponentStack extends Stack {
     // Define an API Gateway for the authentication component public endpoint
     const logGroup = new logs.LogGroup(this, "CustomIdentityAPiAccessLogs");
     const api_gateway = new apigw.RestApi(this, 'ApiGateway', {
-      restApiName: 'CustomIdentityComponentApi',
+      restApiName: 'CustomIdentityComponent',
       description: 'Custom Identity Component API',
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),
@@ -268,7 +269,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -315,7 +317,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName
       }
@@ -396,7 +399,8 @@ export class CustomIdentityComponentStack extends Stack {
         memorySize: 2048,
         environment: {
           "ISSUER_URL": "https://"+distribution.domainName,
-          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+          "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+          "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
           "SECRET_KEY_ID": secret.secretName,
           "USER_TABLE": user_table.tableName,
           "APPLE_APP_ID": appId,
@@ -457,7 +461,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "STEAM_APP_ID": appId,
@@ -528,7 +533,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": privateKeySecret.secretName,
         "USER_TABLE": user_table.tableName,
         "GOOGLE_PLAY_CLIENT_ID": googlePlayClientId,
@@ -598,7 +604,8 @@ export class CustomIdentityComponentStack extends Stack {
       memorySize: 2048,
       environment: {
         "ISSUER_URL": "https://"+distribution.domainName,
-        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponentApi",
+        "POWERTOOLS_METRICS_NAMESPACE": "AWS Game Tech",
+        "POWERTOOLS_SERVICE_NAME": "CustomIdentityComponent",
         "SECRET_KEY_ID": secret.secretName,
         "USER_TABLE": user_table.tableName,
         "FACEBOOK_APP_ID" : appId,

--- a/CustomIdentityComponent/lib/custom_identity_component-stack.ts
+++ b/CustomIdentityComponent/lib/custom_identity_component-stack.ts
@@ -211,7 +211,7 @@ export class CustomIdentityComponentStack extends Stack {
     // Define an API Gateway for the authentication component public endpoint
     const logGroup = new logs.LogGroup(this, "CustomIdentityAPiAccessLogs");
     const api_gateway = new apigw.RestApi(this, 'ApiGateway', {
-      restApiName: 'CustomIdentityComponent',
+      restApiName: 'CustomIdentityComponentApi',
       description: 'Custom Identity Component API',
       deployOptions: {
         accessLogDestination: new apigw.LogGroupLogDestination(logGroup),


### PR DESCRIPTION
Steam Auth improvements based on a similar system built in parallel and in production.

- Read the correct SteamId when borrowing or family sharing
- Use the server to server endpoint per https://partner.steamgames.com/doc/webapi_overview#3
- Handle 103 retry responses (as seen in production)
- Handle VAC and Publisher bans with appropriate logging
- Logging and dead code clean-up
- Use Lambda Power Tools to simplify usage of Secrets Manager
- Added Metrics for the function result and for measuring the response time of the call into Steam.  This is important because many On Call events start with something like "Steam users unable to play..." so quickly root causing or ruling out auth issues via metrics and alarms has expedited resolving live incidents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
